### PR TITLE
Add debug mode for elm

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,6 +108,9 @@ module.exports = function(grunt) {
         },
 
         elm: {
+            options: {
+              debug: true
+            },
             compile: {
                 files: {
                     'build/js/elm.js': 'src/*.elm'
@@ -157,5 +160,4 @@ module.exports = function(grunt) {
         'htmlmin',
         'manifest'
     ]);
-
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-htmlmin": "^0.4.0",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-elm": "^1.4.0",
+    "grunt-elm": "git://github.com/JordyMoos/grunt-elm#add-debug-support",
     "grunt-es6-transpiler": "^1.0.2",
     "grunt-global-config": "^0.1.0",
     "grunt-inline-alt": "^0.3.4",


### PR DESCRIPTION
Met deze PR hebben we die elm state history.
Beetje cheaterig dat grunt nu altijd in debug mode compiled maar grunt uitzoeken is iets voor een andere dag.
Ook is de `grunt-elm` PR nog niet gemerged dus tot die tijd gebruiken we mijn fork