### PR TITLE
Improve the mobile experience a bit

### DIFF
--- a/src/elm/PageState/Auth/Main.elm
+++ b/src/elm/PageState/Auth/Main.elm
@@ -92,6 +92,7 @@ type Msg
     | PasswordEditorMsg PasswordEditor.Msg
     | OpenDeletePasswordModal PasswordId
     | DeletePasswordMsg DeletePassword.Msg
+    | FinishFilter
 
 
 type SupervisorCmd
@@ -154,6 +155,8 @@ libraryEncriptionSuccess =
 update : Msg -> Model -> ( Model, Cmd Msg, SupervisorCmd )
 update msg model =
     case msg of
+        FinishFilter ->
+            ( model, Util.blur "filter" NoOp, None )
         NoOp ->
             ( model, Cmd.none, None )
 
@@ -512,9 +515,10 @@ viewNotification notificationData =
 viewNavBar : Model -> Html Msg
 viewNavBar model =
     nav [ attribute "role" "navigation" ]
-        [ div 
+        [ Html.form 
             [ id "filterContainer"
             , attribute "role" "form"
+            , onSubmit FinishFilter
             ]
             [ input
                 [ id "filter"

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -1,4 +1,4 @@
-module Util exposing ((=>), dictGetWithDefault, isValidPassword, focus)
+module Util exposing ((=>), dictGetWithDefault, isValidPassword, focus, blur)
 
 import Dict exposing (Dict)
 import Dom
@@ -31,4 +31,9 @@ isValidPassword dict passwordKey repeatKey =
 focus : String -> msg -> Cmd msg
 focus elementId onSucessMsg =
     Dom.focus elementId
+        |> Task.attempt (\_ -> onSucessMsg)
+
+blur : String -> msg -> Cmd msg
+blur elementId onSucessMsg =
+    Dom.blur elementId
         |> Task.attempt (\_ -> onSucessMsg)

--- a/src/static/index.ejs
+++ b/src/static/index.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
       <title>Passwords</title>
       <link rel="icon" type="image/png" href="${require('./assets/img/favicon.png')}" />
   </head>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,11 +29,11 @@ var common = {
             inlineSource: '.(js|css)$'
         }),
         new WebpackPwaManifest({
-            name: 'Yet Another Password Manager',
+            name: 'Password Manager',
             short_name: 'Passwords',
-            display: 'fullscreen',
-            orientation: 'portrait',
-            background_color: '#ffffff',
+            display: 'standalone',
+            orientation: 'any',
+            background_color: '#f8f8f8',
             icons: [
                 {
                     src: path.resolve('src/static/assets/img/favicon.png'),


### PR DESCRIPTION
Prevents zoom, enables landscape mode when the device allows for it, hides mobile keyboard on filter submission and sets display to standalone (which always shows the notification bar).

Closes https://github.com/JordyMoos/elm-yapm-client/issues/88.
Closes https://github.com/JordyMoos/elm-yapm-client/issues/87.