### PR TITLE
Be able to override configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ $ yarn dev
  ```
 
 Then goto `localhost:3000` in the browser.
+
+### Override config from environment
+
+All keys set in the `config.json` can be overriden with environment variables from their snakecased-upper name.
+
+For example; to override `maxIdleTime` you can set the environment variable `MAX_IDLE_TIME`.

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import Clipboard from 'clipboard';
-import config from '../../config.json';
+import Config from 'Config';
 import { decryptLibrary, encryptLibrary } from './js/manager.js';
 
 // require('./index.html');
@@ -9,7 +9,7 @@ require("./css/style.css");
 require("./css/yapm.css");
 
 let Elm = require('./../elm/Main');
-let app = Elm.Main.fullscreen(config);
+let app = Elm.Main.fullscreen(Config);
 
 function getErrorMessage(error) {
   if (typeof(error) === 'string') {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,16 @@ var HtmlWebpackInlineSourcePlugin = require('html-webpack-inline-source-plugin')
 var WebpackPwaManifest = require('webpack-pwa-manifest');
 var path = require('path');
 
+var appConfig = require('./config.json');
+for (var key in appConfig) {
+  if (appConfig.hasOwnProperty(key)) {
+    var envName = key.replace(/([A-Z])/g, function($1){return "_"+$1}).toUpperCase();
+    if (envName in process.env) {
+      appConfig[key] = process.env[envName];
+    }
+  }
+}
+
 var TARGET_ENV = process.env.npm_lifecycle_event === 'prod'
     ? 'production'
     : 'development';
@@ -19,6 +29,9 @@ var common = {
         path: path.join(__dirname, "dist"),
         // add hash when building for production
         filename: filename
+    },
+    externals: {
+      'Config': JSON.stringify(appConfig)
     },
     plugins: [
         new HTMLWebpackPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,9 @@ for (var key in appConfig) {
   }
 }
 
+console.log(process.env);
+console.log(appConfig);
+
 var TARGET_ENV = process.env.npm_lifecycle_event === 'prod'
     ? 'production'
     : 'development';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,9 @@ configSchema.forEach(function (propertySchema) {
     appConfig[propertySchema.key] = cast(appConfig[propertySchema.key], propertySchema.type);
 });
 
+console.log('Config used:');
+console.log(appConfig);
+
 var TARGET_ENV = process.env.npm_lifecycle_event === 'prod'
     ? 'production'
     : 'development';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,18 +6,41 @@ var HtmlWebpackInlineSourcePlugin = require('html-webpack-inline-source-plugin')
 var WebpackPwaManifest = require('webpack-pwa-manifest');
 var path = require('path');
 
-var appConfig = require('./config.json');
-for (var key in appConfig) {
-  if (appConfig.hasOwnProperty(key)) {
-    var envName = key.replace(/([A-Z])/g, function($1){return "_"+$1}).toUpperCase();
-    if (envName in process.env) {
-      appConfig[key] = process.env[envName];
+function cast(value, type) {
+    switch (type) {
+        case 'string':
+            return value + '';
+
+        case 'bool':
+            return (value + '') == 'true';
+
+        case 'int':
+            return parseInt(value);
+
+        default:
+            throw 'Invalid type "' + type + '" for casting';
     }
-  }
 }
 
-console.log(process.env);
-console.log(appConfig);
+var configSchema = [
+    { key: 'apiEndPoint', type: 'string' },
+    { key: 'localStorageKey', type: 'string' },
+    { key: 'maxIdleTime', type: 'int' },
+    { key: 'randomPasswordSize', type: 'int' },
+    { key: 'masterKeyAllowEdit', type: 'bool' }
+];
+
+var appConfig = require('./config.json');
+configSchema.forEach(function (propertySchema) {
+    // Overwrite with environment variable if defined
+    var envName = propertySchema.key.replace(/([A-Z])/g, function($1){return "_"+$1}).toUpperCase();
+    if (envName in process.env) {
+        appConfig[propertySchema.key] = value;
+    }
+
+    // Cast to the proper type
+    appConfig[propertySchema.key] = cast(appConfig[propertySchema.key], propertySchema.type);
+});
 
 var TARGET_ENV = process.env.npm_lifecycle_event === 'prod'
     ? 'production'


### PR DESCRIPTION
With this PR, you can override all properties in the config.json via the environment.
This allows the yapm-docker setup the overwrite the apiEndPoint so you do not need to change that yourself.